### PR TITLE
adjusted category pages to use new utils function for path sensitive …

### DIFF
--- a/src/app/[locale]/(routes)/[category]/[subcategory]/[segment]/page.tsx
+++ b/src/app/[locale]/(routes)/[category]/[subcategory]/[segment]/page.tsx
@@ -7,6 +7,7 @@ import type { FilterCategory } from "@/components/ui/filter";
 import { useCategories } from "@/lib/CategoriesProvider";
 import {
 	findSubCategoryRecursive,
+	findCategoryByPath,
 	normalizeFilterResponse,
 } from "@/lib/category-utils";
 import { formatUrlToDisplayName } from "@/lib/utils";
@@ -43,11 +44,16 @@ export default function SegmentPage({ params }: SegmentPageProps) {
 	useEffect(() => {
 		if (!categories) return;
 
-		const subCategoryData = findSubCategoryRecursive(
-			categories,
-			formattedSubCategory,
-			formattedSegment,
-		);
+		// const subCategoryData = findSubCategoryRecursive(
+		// 	categories,
+		// 	formattedSubCategory,
+		// 	formattedSegment,
+		// );
+		const subCategoryData = findCategoryByPath(categories, [
+			category,
+			subcategory,
+			segment,
+		]);
 
 		setCategoryData(subCategoryData);
 

--- a/src/app/[locale]/(routes)/[category]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(routes)/[category]/[subcategory]/page.tsx
@@ -7,7 +7,8 @@ import type { FilterCategory } from "@/components/ui/filter";
 import { useCategories } from "@/lib/CategoriesProvider";
 import {
 	findSubCategoryRecursive,
-	normalizeFilterResponse,
+	findCategoryByPath,
+	normalizeFilterResponse
 } from "@/lib/category-utils";
 import { formatUrlToDisplayName } from "@/lib/utils";
 import { loadFilterParents } from "@/services/categories.service";
@@ -16,12 +17,13 @@ import { useLocale } from "next-intl";
 
 interface SubCategoryPageProps {
 	params: Promise<{
+		category: string;
 		subcategory: string;
 	}>;
 }
 
 export default function SubCategoryPage({ params }: SubCategoryPageProps) {
-	const { subcategory } = use(params);
+	const { category, subcategory } = use(params);
 	const locale = useLocale();
 
 	const { categories } = useCategories();
@@ -37,10 +39,14 @@ export default function SubCategoryPage({ params }: SubCategoryPageProps) {
 	useEffect(() => {
 		if (!categories) return;
 
-		const subCategoryData = findSubCategoryRecursive(
-			categories,
-			formattedSubCategory,
-		);
+		//Old Recursive variant
+		// const subCategoryData = findSubCategoryRecursive(
+		// 	categories,
+		// 	formattedSubCategory,
+		// );
+		//New variant path-sensitive
+		const subCategoryData = findCategoryByPath(categories, [category, subcategory]);
+
 
 		setCategoryData(subCategoryData);
 

--- a/src/lib/category-utils.ts
+++ b/src/lib/category-utils.ts
@@ -26,6 +26,7 @@ export async function findCategoryByName(categories: Category[], name: string) {
 	);
 }
 
+//Old Category Lookup: non-path sensitive (aka lookup on name)
 export function findSubCategoryRecursive(
 	categories: Category[],
 	subcategoryName: string,
@@ -56,6 +57,26 @@ export function findSubCategoryRecursive(
 	}
 	return null;
 }
+
+//new category lookup: path sensitive, forces match per slug, we send in top to bottom slugs, so
+//first top category, then subcategory, then segment, we can also only send 2 first  or just the main cat
+export function findCategoryByPath(
+	categories: Category[],
+	slugs: string[],
+): Category | null {
+	let current: Category | null = null;
+	let level = categories;
+
+	for (const slug of slugs) {
+		current = level.find((c) => c.slug === slug) ?? null;
+		if (!current) return null;
+		level = current.subcategories || [];
+	}
+
+	return current;
+}
+
+
 
 export async function fetchProducts(
 	categoryNumber: string | null,


### PR DESCRIPTION
…subcat lookups

Issue:
Some catalogues have identical names for differently placed segments aka multiple categories named "Bukser" with "depth": 3,
new function in category-utils.ts that takes in 1-3 paths instead of stopping on first match (I believe we sat scope that folders would be unique per assortment, but this is apparently not the case anymore)

Obs: Did not touch the useBreadcrumbs.ts file, that is still using the old recursive func. 
