### PR TITLE
quickfix for name showing in tab header

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -27,7 +27,7 @@
 		"viewAll": "See all categories"
 	},
 	"Product": {
-		"notFound": "Product not found",
+		"notFound": "TESS - Teknisk Faghandel | Netthandel",
 		"seeAllVariants": "See all variants",
 		"copied": "Copied!",
 		"productDescription": "Product Description",

--- a/messages/no.json
+++ b/messages/no.json
@@ -29,7 +29,7 @@
 		"customerSpecificProducts": "Kundespesifikke produkter"
 	},
 	"Product": {
-		"notFound": "Produkt ikke funnet",
+		"notFound": "TESS - Teknisk Faghandel | Netthandel",
 		"seeAllVariants": "Se alle varianter",
 		"copied": "Kopiert!",
 		"productDescription": "Produktbeskrivelse",


### PR DESCRIPTION
Did a quick-fix to show TESS in the header of the browser tab instead of "Produkt ikke funnet" which was misleading to some users
ToDo:
Add in logic to grab productnumber and show in tab instead (or just keep tessix name and remove traces of find logic) 