### PR TITLE
Bug fix warehouse stock showing aggregated on warehouse number

### DIFF
--- a/src/components/checkout/product-variant-table.tsx
+++ b/src/components/checkout/product-variant-table.tsx
@@ -505,7 +505,7 @@ export default function ProductVariantTable({
 						.slice(0, 50)
 						.sort((a: any, b: any) => b.balance - a.balance);
 
-					const warehouses = warehouseOptions.map((w) => ({
+					const warehouses = warehouseOptions.map((w: { warehouseId: { toString: () => any; }; warehouseName: any; balance: any; }) => ({
 						warehouseNumber: w.warehouseId.toString(),
 						warehouseName: w.warehouseName,
 						balance: w.balance,

--- a/src/components/checkout/product-variant-table.tsx
+++ b/src/components/checkout/product-variant-table.tsx
@@ -121,10 +121,12 @@ export default function ProductVariantTable({
 	const [prices, setPrices] = useState<Record<number, number>>({});
 	const [loading, setLoading] = useState<Record<number, boolean>>({});
 	const initializedWarehousesRef = useRef<Set<number>>(new Set());
+	const pendingWarehouseChangesRef = useRef<Array<[string, string]>>([]);
 
 	// Reset initialized warehouses when variants change
 	useEffect(() => {
 		initializedWarehousesRef.current.clear();
+		pendingWarehouseChangesRef.current = [];
 	}, [variants]);
 
 	const [visibleCols, setVisibleCols] = useState<Record<ColumnKey, boolean>>({
@@ -219,31 +221,27 @@ export default function ProductVariantTable({
 		variantsWithWarehouses.forEach((variant) => {
 			const inventory = columnAttributes?.[variant.itemNumber]?.inventory || [];
 
-			const warehouseMap = new Map();
-			inventory
-				.filter((inv: any) => inv.balance > 0)
-				.forEach((inv: any) => {
-					const key = inv.warehouseId;
-					if (warehouseMap.has(key)) {
-						warehouseMap.get(key).balance += inv.balance;
-					} else {
-						warehouseMap.set(key, {
-							warehouseId: inv.warehouseId,
-							warehouseName:
-								inv.warehouseName ||
-								`${t("Product.warehouses")} ${inv.warehouseId}`,
-							balance: inv.balance,
-						});
-					}
-				});
-
-			optionsMap[variant.itemNumber] = Array.from(warehouseMap.values())
+			// Filter by company number and positive balance only
+			const warehouseOptions = inventory
+				.filter((inv: any) => 
+					inv.balance > 0 && 
+					inv.companyNumber === profile?.defaultCompanyNumber
+				)
+				.map((inv: any) => ({
+					warehouseId: inv.warehouseId,
+					warehouseName:
+						inv.warehouseName ||
+						`${t("Product.warehouses")} ${inv.warehouseId}`,
+					balance: inv.balance,
+				}))
 				.slice(0, 50)
 				.sort((a: any, b: any) => b.balance - a.balance);
+
+			optionsMap[variant.itemNumber] = warehouseOptions;
 		});
 
 		return optionsMap;
-	}, [variantsWithWarehouses, columnAttributes]);
+	}, [variantsWithWarehouses, columnAttributes, profile?.defaultCompanyNumber]);
 
 	useEffect(() => {
 		if (!allAttributeNames?.length) return;
@@ -346,6 +344,16 @@ export default function ProductVariantTable({
 			return next;
 		});
 	}, [allAttributeNames, visibleCols, isSapCustomer, columnAttributes]);
+
+	// Process pending warehouse changes after state updates to avoid updating parent during render
+	useEffect(() => {
+		if (pendingWarehouseChangesRef.current.length > 0 && onWarehouseChange) {
+			pendingWarehouseChangesRef.current.forEach(([itemNumber, warehouseNumber]) => {
+				onWarehouseChange(itemNumber, warehouseNumber);
+			});
+			pendingWarehouseChangesRef.current = [];
+		}
+	}, [warehouse, onWarehouseChange]);
 
 	const getTotalVisibleColumns = () => {
 		const visibleStaticCount = Object.entries(visibleCols).filter(
@@ -480,25 +488,20 @@ export default function ProductVariantTable({
 					// Compute warehouse options directly from variants and columnAttributes
 					const inventory =
 						columnAttributes?.[variant.itemNumber]?.inventory || [];
-					const warehouseMap = new Map();
-					inventory
-						.filter((inv: any) => inv.balance > 0)
-						.forEach((inv: any) => {
-							const key = inv.warehouseId;
-							if (warehouseMap.has(key)) {
-								warehouseMap.get(key).balance += inv.balance;
-							} else {
-								warehouseMap.set(key, {
-									warehouseId: inv.warehouseId,
-									warehouseName:
-										inv.warehouseName ||
-										`${t("Product.warehouses")} ${inv.warehouseId}`,
-									balance: inv.balance,
-								});
-							}
-						});
-
-					const warehouseOptions = Array.from(warehouseMap.values())
+					
+					// Filter for positive balance and matching company number, then sort
+					const warehouseOptions = inventory
+						.filter((inv: any) => 
+							inv.balance > 0 && 
+							inv.companyNumber === profile?.defaultCompanyNumber
+						)
+						.map((inv: any) => ({
+							warehouseId: inv.warehouseId,
+							warehouseName:
+								inv.warehouseName ||
+								`${t("Product.warehouses")} ${inv.warehouseId}`,
+							balance: inv.balance,
+						}))
 						.slice(0, 50)
 						.sort((a: any, b: any) => b.balance - a.balance);
 
@@ -520,8 +523,8 @@ export default function ProductVariantTable({
 									initializedWarehousesRef.current.add(variantKey);
 									return prev; // Keep existing selection
 								}
-								// Preselect first available warehouse and notify parent
-								onWarehouseChange?.(variantKey.toString(), firstWarehouse);
+								// Queue the parent notification for later (after state update)
+								pendingWarehouseChangesRef.current.push([variantKey.toString(), firstWarehouse]);
 								initializedWarehousesRef.current.add(variantKey);
 								return {
 									...prev,

--- a/src/components/products/product-info.tsx
+++ b/src/components/products/product-info.tsx
@@ -221,28 +221,40 @@ export function ProductInfo({
 	}, [selectedItemNumber, columnAttributes, t]);
 
 	// Get warehouse info for selected warehouse
-	const warehouseNumber = selectedWarehouse || profile?.defaultWarehouseNumber;
-
 	const getWarehouseInfo = () => {
-		if (!selectedItemNumber || !columnAttributes || !warehouseNumber)
-			return null;
+		if (!selectedItemNumber || !columnAttributes) return null;
+		if (!selectedWarehouse && !profile?.defaultWarehouseNumber) return null;
 
 		const inventory = columnAttributes[selectedItemNumber]?.inventory || [];
-		const warehouseId = parseInt(warehouseNumber);
-		const warehouseInfo = inventory.find(
-			(inv: any) => inv.warehouseId === warehouseId,
-		);
+		
+		let warehouseInfo;
+		
+		if (selectedWarehouse) {
+			// selectedWarehouse from table is warehouseId (unique)
+			const warehouseId = parseInt(selectedWarehouse);
+			warehouseInfo = inventory.find((inv: any) => inv.warehouseId === warehouseId);
+		} else {
+			// profile default uses warehouseNumber + companyNumber (combination is unique)
+			const defaultWarehouseNumber = profile?.defaultWarehouseNumber;
+			const defaultCompanyNumber = profile?.defaultCompanyNumber;
+			warehouseInfo = inventory.find(
+				(inv: any) => 
+					inv.warehouseNumber === defaultWarehouseNumber &&
+					inv.companyNumber === defaultCompanyNumber,
+			);
+		}
 
 		if (warehouseInfo) {
 			return {
 				balance: warehouseInfo.balance || 0,
-				warehouseName: warehouseInfo.warehouseName || `Lager ${warehouseId}`,
+				warehouseName: warehouseInfo.warehouseName || `Lager ${warehouseInfo.warehouseId}`,
 			};
 		}
 
 		return null;
 	};
 
+	// Get warehouse info for selected warehouse (unique by warehouseId or warehouseNumber+companyNumber)
 	const warehouseInfo = getWarehouseInfo();
 	const selectedWarehouseBalance = warehouseInfo
 		? warehouseInfo.balance
@@ -250,9 +262,10 @@ export function ProductInfo({
 
 	const selectedWarehouseName = warehouseInfo
 		? warehouseInfo.warehouseName
-		: warehouseNumber
-			? `Lager ${warehouseNumber}`
-			: "hovedlager";
+		: "hovedlager";
+
+	// For warehouse selection dropdown display
+	const warehouseNumber = selectedWarehouse || profile?.defaultWarehouseNumber;
 
 	// Get unit (enhet) for the selected item
 	const getUnit = () => {

--- a/src/components/products/product-variant-info.tsx
+++ b/src/components/products/product-variant-info.tsx
@@ -74,46 +74,43 @@ export function ProductVariantInfo({
 
 	const sapNumber = getSapNumber();
 
-	// Get stock balance and warehouse name for selected warehouse (from table selection or default warehouse)
-	const warehouseNumber = selectedWarehouse || profile?.defaultWarehouseNumber;
-
 	// Get warehouse info from columnAttributes (inventory data) if available
 	const getWarehouseInfo = () => {
 		if (!selectedItemNumber || !columnAttributes) return null;
 
 		const inventory = columnAttributes[selectedItemNumber]?.inventory || [];
-		if (!warehouseNumber) return null;
+		if (!selectedWarehouse && !profile?.defaultWarehouseNumber) return null;
 
-		const warehouseId = parseInt(warehouseNumber);
-		const warehouseInfo = inventory.find(
-			(inv: any) => inv.warehouseId === warehouseId,
-		);
+		let warehouseInfo;
+		
+		if (selectedWarehouse) {
+			// selectedWarehouse from table is warehouseId (unique)
+			const warehouseId = parseInt(selectedWarehouse);
+			warehouseInfo = inventory.find((inv: any) => inv.warehouseId === warehouseId);
+		} else {
+			// profile default uses warehouseNumber + companyNumber (combination is unique)
+			const defaultWarehouseNumber = profile?.defaultWarehouseNumber;
+			const defaultCompanyNumber = profile?.defaultCompanyNumber;
+			warehouseInfo = inventory.find(
+				(inv: any) => 
+					inv.warehouseNumber === defaultWarehouseNumber &&
+					inv.companyNumber === defaultCompanyNumber,
+			);
+		}
 
 		if (warehouseInfo) {
 			return {
 				balance: warehouseInfo.balance || 0,
-				warehouseName: warehouseInfo.warehouseName || `Lager ${warehouseId}`,
+				warehouseName: warehouseInfo.warehouseName || `Lager ${warehouseInfo.warehouseId}`,
 			};
 		}
 
 		return null;
 	};
 
-	// Fallback to stockByWarehouse if columnAttributes not available
 	const warehouseInfo = getWarehouseInfo();
-	const selectedWarehouseBalance = warehouseInfo
-		? warehouseInfo.balance
-		: warehouseNumber
-			? (variantData?.stockByWarehouse?.find(
-					(w: any) => w.warehouse_number === warehouseNumber,
-				)?.balance ?? 0)
-			: 0;
-
-	const selectedWarehouseName = warehouseInfo
-		? warehouseInfo.warehouseName
-		: warehouseNumber
-			? `Lager ${warehouseNumber}`
-			: "hovedlager";
+	const selectedWarehouseBalance = warehouseInfo ? warehouseInfo.balance : 0;
+	const selectedWarehouseName = warehouseInfo ? warehouseInfo.warehouseName : "hovedlager";
 
 	// Get unit (enhet) for the selected item
 	const getUnit = () => {


### PR DESCRIPTION
there was a map doing warehouseNumber = warehouseNumber (in code it was written as warehouseId = warehouseNumber effectively, which ends up causing a weird bug where balances got aggregated on warehouses sharing a warehosenumber as theyre not unique)
The fix implemented just added companynumber as a check as well, so a composite key on companyNumber+warehouseNumber making sure we're not accidentaly merging multiple warehouses

Future plan: should perhaps just re-use the warehouse logic implemented in cart to have a uniform design 